### PR TITLE
Upgrade Spring Boot and use feign-httpclient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'checkstyle'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'org.springframework.boot' version '2.0.5.RELEASE'
+    id 'org.springframework.boot' version '2.1.2.RELEASE'
     id 'com.jfrog.bintray' version '1.8.4'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'java-library'
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.2'
+version '0.0.3'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
@@ -130,7 +130,8 @@ bintray {
 
 ext {
     lombokVersion = '1.18.2'
-    springCloudVersion = 'Finchley.RELEASE'
+    springCloudVersion = 'Greenwich.RELEASE'
+    feignVersion = '10.1.0'
 }
 
 dependencyManagement {
@@ -142,7 +143,8 @@ dependencyManagement {
 dependencies {
     api group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
     api group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    api group: 'io.github.openfeign', name: 'feign-jackson'
+    api group: 'io.github.openfeign', name: 'feign-jackson', version: feignVersion
+    api group: 'io.github.openfeign', name: 'feign-httpclient', version: feignVersion
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion


### PR DESCRIPTION
### Change description ###

- Upgrade Spring Boot to version 2.1.2.RELEASE
- Use feign-httpclient version 10.1.0

The above changes are necessary to cause empty POST requests to include Content-Length header, which is required in CNP.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
