### PR TITLE
Added body to idam requests as it is needed by MS IIS server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ ext {
     lombokVersion = '1.18.2'
     springCloudVersion = 'Greenwich.RELEASE'
     feignVersion = '10.1.0'
+    feignFormVersion = '3.5.0'
 }
 
 dependencyManagement {
@@ -145,6 +146,7 @@ dependencies {
     api group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     api group: 'io.github.openfeign', name: 'feign-jackson', version: feignVersion
     api group: 'io.github.openfeign', name: 'feign-httpclient', version: feignVersion
+    api group: 'io.github.openfeign.form', name: 'feign-form', version: feignFormVersion
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.3'
+version '0.0.4'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/CoreFeignConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/CoreFeignConfiguration.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.idam.client;
+
+import feign.codec.Encoder;
+import feign.form.FormEncoder;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+
+
+@Configuration
+public class CoreFeignConfiguration {
+    @Autowired
+    private ObjectFactory<HttpMessageConverters> messageConverters;
+
+    @Bean
+    @Primary
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    Encoder feignFormEncoder() {
+        return new FormEncoder(new SpringEncoder(this.messageConverters));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.idam.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -24,6 +25,11 @@ public interface IdamApi {
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     );
 
+    /**
+     * This method accepts request body but it has to be always passed as " ".
+     * This is to ensure that spring cloud feign implementation adds a content length header
+     * which is required by Microsoft IIS server else it returns 411 Error back.
+     */
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/oauth2/authorize",
@@ -33,9 +39,15 @@ public interface IdamApi {
         @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation,
         @RequestParam("response_type") final String responseType,
         @RequestParam("client_id") final String clientId,
-        @RequestParam("redirect_uri") final String redirectUri
+        @RequestParam("redirect_uri") final String redirectUri,
+        @RequestBody String requestBody
     );
 
+    /**
+     * This method accepts request body but it has to be always passed as " ".
+     * This is to ensure that spring cloud feign implementation adds a content length header
+     * which is required by Microsoft IIS server else it returns 411 Error back.
+     */
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/oauth2/token",
@@ -46,6 +58,7 @@ public interface IdamApi {
         @RequestParam("grant_type") final String grantType,
         @RequestParam("redirect_uri") final String redirectUri,
         @RequestParam("client_id") final String clientId,
-        @RequestParam("client_secret") final String clientSecret
+        @RequestParam("client_secret") final String clientSecret,
+        @RequestBody String requestBody
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
@@ -25,11 +25,7 @@ public interface IdamApi {
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     );
 
-    /**
-     * This method accepts request body but it has to be always passed as " ".
-     * This is to ensure that spring cloud feign implementation adds a content length header
-     * which is required by Microsoft IIS server else it returns 411 Error back.
-     */
+
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/oauth2/authorize",
@@ -43,11 +39,7 @@ public interface IdamApi {
         @RequestBody String requestBody
     );
 
-    /**
-     * This method accepts request body but it has to be always passed as " ".
-     * This is to ensure that spring cloud feign implementation adds a content length header
-     * which is required by Microsoft IIS server else it returns 411 Error back.
-     */
+
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/oauth2/token",

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
@@ -7,14 +7,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.idam.client.models.AuthenticateUserResponse;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
-@FeignClient(name = "idam-api", url = "${idam.api.url}")
+import java.util.Map;
+
+@FeignClient(name = "idam-api", url = "${idam.api.url}", configuration = CoreFeignConfiguration.class)
 public interface IdamApi {
     @RequestMapping(method = RequestMethod.GET, value = "/details")
     UserDetails retrieveUserDetails(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation);
@@ -33,10 +34,7 @@ public interface IdamApi {
     )
     AuthenticateUserResponse authenticateUser(
         @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorisation,
-        @RequestParam("response_type") final String responseType,
-        @RequestParam("client_id") final String clientId,
-        @RequestParam("redirect_uri") final String redirectUri,
-        @RequestBody String requestBody
+        @RequestBody Map<String, ?> requestBody
     );
 
 
@@ -46,11 +44,6 @@ public interface IdamApi {
         consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
     )
     TokenExchangeResponse exchangeCode(
-        @RequestParam("code") final String code,
-        @RequestParam("grant_type") final String grantType,
-        @RequestParam("redirect_uri") final String redirectUri,
-        @RequestParam("client_id") final String clientId,
-        @RequestParam("client_secret") final String clientSecret,
-        @RequestBody String requestBody
+        @RequestBody Map<String, ?> requestBody
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -50,13 +50,8 @@ public class IdamClient {
         authenticateUserReqBody.put(CLIENT_ID, clientId);
         authenticateUserReqBody.put(REDIRECT_URI, redirectUri);
 
-        AuthenticateUserResponse authenticateUserResponse = idamApi.authenticateUser(
-            BASIC_AUTH_TYPE + " " + base64Authorisation,
-            AUTH_TYPE,
-            clientId,
-            redirectUri,
-            authenticateUserReqBody.toString()
-        );
+        AuthenticateUserResponse authenticateUserResponse =
+            idamApi.authenticateUser(BASIC_AUTH_TYPE + " " + base64Authorisation, authenticateUserReqBody);
 
         Map<String, String> tokenExchangeReqBody = new HashMap<>();
         tokenExchangeReqBody.put(CODE, authenticateUserResponse.getCode());
@@ -65,15 +60,10 @@ public class IdamClient {
         tokenExchangeReqBody.put(CLIENT_ID, clientId);
         tokenExchangeReqBody.put(CLIENT_SECRET, oauth2Configuration.getClientSecret());
 
-        TokenExchangeResponse tokenExchangeResponse = idamApi.exchangeCode(
-            authenticateUserResponse.getCode(),
-            AUTHORIZATION_CODE,
-            redirectUri,
-            clientId,
-            oauth2Configuration.getClientSecret(),
-            tokenExchangeReqBody.toString()
-        );
+
+        TokenExchangeResponse tokenExchangeResponse = idamApi.exchangeCode(tokenExchangeReqBody);
 
         return BEARER_AUTH_TYPE + " " + tokenExchangeResponse.getAccessToken();
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -34,18 +34,20 @@ public class IdamClient {
         String base64Authorisation = Base64.getEncoder().encodeToString(authorisation.getBytes());
 
         AuthenticateUserResponse authenticateUserResponse = idamApi.authenticateUser(
-                BASIC_AUTH_TYPE + " " + base64Authorisation,
-                AUTH_TYPE,
-                oauth2Configuration.getClientId(),
-                oauth2Configuration.getRedirectUri()
+            BASIC_AUTH_TYPE + " " + base64Authorisation,
+            AUTH_TYPE,
+            oauth2Configuration.getClientId(),
+            oauth2Configuration.getRedirectUri(),
+            " "
         );
 
         TokenExchangeResponse tokenExchangeResponse = idamApi.exchangeCode(
-                authenticateUserResponse.getCode(),
-                GRANT_TYPE,
-                oauth2Configuration.getRedirectUri(),
-                oauth2Configuration.getClientId(),
-                oauth2Configuration.getClientSecret()
+            authenticateUserResponse.getCode(),
+            GRANT_TYPE,
+            oauth2Configuration.getRedirectUri(),
+            oauth2Configuration.getClientId(),
+            oauth2Configuration.getClientSecret(),
+            " "
         );
 
         return BEARER_AUTH_TYPE + " " + tokenExchangeResponse.getAccessToken();

--- a/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest(classes = {IdamClientAutoConfiguration.class, IdamClient.class, IdamApi.class})
 @ExtendWith({
-        SpringExtension.class
+    SpringExtension.class
 })
 @EnableAutoConfiguration
 @AutoConfigureWireMock
@@ -30,7 +30,12 @@ class IdamClientTest {
     void authenticateUser() {
         // user is configured in wiremock json file as should return successful
         String bearerToken = idamClient.authenticateUser("user@example.com", "Password12");
-        assertThat(bearerToken).isEqualTo("Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzYTY3MmJkdm5tYW1sZmFlaDB2ODFia2V1NyIsInN1YiI6IjI0IiwiaWF0IjoxNTUwNjY2ODM0LCJleHAiOjE1NTA2OTU2MzQsImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlci1zc2NzLWxvYTAiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIyNCIsImZvcmVuYW1lIjoiQnVsayBTY2FuIiwic3VybmFtZSI6IlN5c3RlbSBVcGRhdGUiLCJkZWZhdWx0LXNlcnZpY2UiOiJCU1AiLCJsb2EiOjAsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvYnNwIiwiZ3JvdXAiOiJic3Atc3lzdGVtdXBkYXRlIn0.BbVZAYAkRq5o0aPD5TIk-jmVeo20f9RPNPUFYhrbz5s");
+        assertThat(bearerToken).isEqualTo("Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ1c2FubmJyaGV2OWI0dGxzMzhy"
+            + "MTI4dGdycCIsInN1YiI6IjI0IiwiaWF0IjoxNTUwNjk1Nzc5LCJleHAiOjE1NTA3MjQ1NzksImRhdGEiOiJjYXNld29ya2"
+            + "VyLXNzY3MsY2FzZXdvcmtlci1zc2NzLWxvYTAiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIyNCIsImZvcmVuYW1lIjoiQnVs"
+            + "ayBTY2FuIiwic3VybmFtZSI6IlN5c3RlbSBVcGRhdGUiLCJkZWZhdWx0LXNlcnZpY2UiOiJCU1AiLCJsb2EiOjAsImRlZm"
+            + "F1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvYnNwIiwiZ3JvdXAiOiJic3Atc3lzdGVtdXBkYXRlIn0.P"
+            + "djD2Kjz6myH1p44CRCVztkl2lqkg0LXqiyoH7Hs2bg");
     }
 
     @Test
@@ -38,7 +43,7 @@ class IdamClientTest {
     void failedToAuthenticateUser() {
         // user is configured in wiremock json file as should return 401
         FeignException exception = assertThrows(FeignException.class, () ->
-                idamClient.authenticateUser("anotheruser@example.com", "Password123")
+            idamClient.authenticateUser("anotheruser@example.com", "Password123")
         );
 
         assertThat(exception.status()).isEqualTo(HttpStatus.UNAUTHORIZED.value());

--- a/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
@@ -30,13 +30,7 @@ class IdamClientTest {
     void authenticateUser() {
         // user is configured in wiremock json file as should return successful
         String bearerToken = idamClient.authenticateUser("user@example.com", "Password12");
-        assertThat(bearerToken).isEqualTo("Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ2YjRrYTlwYW"
-                + "c5a2x2a3Bqczhqb241bDhrdCIsInN1YiI6IjMxIiwiaWF0IjoxNTM3MzcwMDgxLCJleHAiOjE1Mz"
-                + "czOTg4ODEsImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlcixjYXNld29ya2VyLXNzY3"
-                + "MtbG9hMSxjYXNld29ya2VyLWxvYTEiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIzMSIsImZvcmVuYW"
-                + "1lIjoiQ2FzZSIsInN1cm5hbWUiOiJXb3JrZXIiLCJkZWZhdWx0LXNlcnZpY2UiOiJDQ0QiLCJsb2"
-                + "EiOjEsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvY2NkIiwiZ3JvdX"
-                + "AiOiJjYXNld29ya2VyIn0.F3qGuDsFb_8hgyFHMNjEow0RMTTaBz2VIuRTZpbVa80");
+        assertThat(bearerToken).isEqualTo("Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzYTY3MmJkdm5tYW1sZmFlaDB2ODFia2V1NyIsInN1YiI6IjI0IiwiaWF0IjoxNTUwNjY2ODM0LCJleHAiOjE1NTA2OTU2MzQsImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlci1zc2NzLWxvYTAiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIyNCIsImZvcmVuYW1lIjoiQnVsayBTY2FuIiwic3VybmFtZSI6IlN5c3RlbSBVcGRhdGUiLCJkZWZhdWx0LXNlcnZpY2UiOiJCU1AiLCJsb2EiOjAsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvYnNwIiwiZ3JvdXAiOiJic3Atc3lzdGVtdXBkYXRlIn0.BbVZAYAkRq5o0aPD5TIk-jmVeo20f9RPNPUFYhrbz5s");
     }
 
     @Test

--- a/src/test/resources/mappings/oauth2_authorize-successful.json
+++ b/src/test/resources/mappings/oauth2_authorize-successful.json
@@ -1,26 +1,33 @@
 {
-  "id" : "e3c087f5-1e25-419c-876b-5830e780b7e1",
+  "id" : "c45aa693-f13f-455f-bd77-126ab4270840",
   "name" : "oauth2_authorize",
   "request" : {
     "url" : "/oauth2/authorize?response_type=code&client_id=bsp&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver",
     "method" : "POST",
     "headers": {
       "Authorization": {
-          "equalTo": "Basic dXNlckBleGFtcGxlLmNvbTpQYXNzd29yZDEy"
+        "equalTo": "Basic dXNlckBleGFtcGxlLmNvbTpQYXNzd29yZDEy"
       }
-    }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "{response_type=code, redirect_uri=https://localhost/receiver, client_id=bsp}",
+      "caseInsensitive" : false
+    } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"code\":\"6GugDwpBcfq5E549\"}",
+    "body" : "{\"code\":\"TkREejRRxTUp6U9u\"}",
     "headers" : {
       "X-Application-Context" : "application",
       "Content-Type" : "application/json;charset=UTF-8",
       "Vary" : "Accept-Encoding",
-      "Date" : "Wed, 19 Sep 2018 15:14:41 GMT"
+      "Date" : "Wed, 20 Feb 2019 12:47:14 GMT"
     }
   },
-  "uuid" : "e3c087f5-1e25-419c-876b-5830e780b7e1",
+  "uuid" : "c45aa693-f13f-455f-bd77-126ab4270840",
   "persistent" : true,
-  "insertionIndex" : 1
+  "scenarioName" : "scenario-oauth2-authorize",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-oauth2-authorize-2",
+  "insertionIndex" : 2
 }

--- a/src/test/resources/mappings/oauth2_authorize-successful.json
+++ b/src/test/resources/mappings/oauth2_authorize-successful.json
@@ -1,8 +1,8 @@
 {
-  "id" : "c45aa693-f13f-455f-bd77-126ab4270840",
+  "id" : "93fd5bfc-ae51-47f8-a12d-07cf8e47b1cc",
   "name" : "oauth2_authorize",
   "request" : {
-    "url" : "/oauth2/authorize?response_type=code&client_id=bsp&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver",
+    "url" : "/oauth2/authorize",
     "method" : "POST",
     "headers": {
       "Authorization": {
@@ -10,24 +10,24 @@
       }
     },
     "bodyPatterns" : [ {
-      "equalTo" : "{response_type=code, redirect_uri=https://localhost/receiver, client_id=bsp}",
+      "equalTo" : "response_type=code&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver&client_id=bsp",
       "caseInsensitive" : false
     } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"code\":\"TkREejRRxTUp6U9u\"}",
+    "body" : "{\"code\":\"eEdhNnasWy7eNFAV\"}",
     "headers" : {
       "X-Application-Context" : "application",
       "Content-Type" : "application/json;charset=UTF-8",
       "Vary" : "Accept-Encoding",
-      "Date" : "Wed, 20 Feb 2019 12:47:14 GMT"
+      "Date" : "Wed, 20 Feb 2019 20:49:39 GMT"
     }
   },
-  "uuid" : "c45aa693-f13f-455f-bd77-126ab4270840",
+  "uuid" : "93fd5bfc-ae51-47f8-a12d-07cf8e47b1cc",
   "persistent" : true,
   "scenarioName" : "scenario-oauth2-authorize",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-oauth2-authorize-2",
-  "insertionIndex" : 2
+  "insertionIndex" : 3
 }

--- a/src/test/resources/mappings/oauth2_authorize-unsuccessful.json
+++ b/src/test/resources/mappings/oauth2_authorize-unsuccessful.json
@@ -1,5 +1,5 @@
 {
-  "id" : "335a8327-5ee2-4030-a05f-de3abd778031",
+  "id" : "64953a35-55cb-4627-9702-4447c974c61a",
   "name" : "oauth2_authorize",
   "request" : {
     "url" : "/oauth2/authorize?response_type=code&client_id=bsp&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver",
@@ -8,7 +8,11 @@
       "Authorization": {
         "equalTo": "Basic YW5vdGhlcnVzZXJAZXhhbXBsZS5jb206UGFzc3dvcmQxMjM="
       }
-    }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "{response_type=code, redirect_uri=https://localhost/receiver, client_id=bsp}",
+      "caseInsensitive" : false
+    } ]
   },
   "response" : {
     "status" : 401,
@@ -17,10 +21,12 @@
       "X-Application-Context" : "application",
       "Content-Type" : "application/json;charset=UTF-8",
       "Vary" : "Accept-Encoding",
-      "Date" : "Wed, 19 Sep 2018 15:35:36 GMT"
+      "Date" : "Wed, 20 Feb 2019 12:47:14 GMT"
     }
   },
-  "uuid" : "335a8327-5ee2-4030-a05f-de3abd778031",
+  "uuid" : "64953a35-55cb-4627-9702-4447c974c61a",
   "persistent" : true,
-  "insertionIndex" : 1
+  "scenarioName" : "scenario-oauth2-authorize",
+  "requiredScenarioState" : "scenario-oauth2-authorize-2",
+  "insertionIndex" : 4
 }

--- a/src/test/resources/mappings/oauth2_authorize-unsuccessful.json
+++ b/src/test/resources/mappings/oauth2_authorize-unsuccessful.json
@@ -1,8 +1,8 @@
 {
-  "id" : "64953a35-55cb-4627-9702-4447c974c61a",
+  "id" : "83fbf4b2-f221-46d7-9c61-f29b9b745c54",
   "name" : "oauth2_authorize",
   "request" : {
-    "url" : "/oauth2/authorize?response_type=code&client_id=bsp&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver",
+    "url" : "/oauth2/authorize",
     "method" : "POST",
     "headers": {
       "Authorization": {
@@ -10,7 +10,7 @@
       }
     },
     "bodyPatterns" : [ {
-      "equalTo" : "{response_type=code, redirect_uri=https://localhost/receiver, client_id=bsp}",
+      "equalTo" : "response_type=code&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver&client_id=bsp",
       "caseInsensitive" : false
     } ]
   },
@@ -21,12 +21,12 @@
       "X-Application-Context" : "application",
       "Content-Type" : "application/json;charset=UTF-8",
       "Vary" : "Accept-Encoding",
-      "Date" : "Wed, 20 Feb 2019 12:47:14 GMT"
+      "Date" : "Wed, 20 Feb 2019 20:49:39 GMT"
     }
   },
-  "uuid" : "64953a35-55cb-4627-9702-4447c974c61a",
+  "uuid" : "83fbf4b2-f221-46d7-9c61-f29b9b745c54",
   "persistent" : true,
   "scenarioName" : "scenario-oauth2-authorize",
   "requiredScenarioState" : "scenario-oauth2-authorize-2",
-  "insertionIndex" : 4
+  "insertionIndex" : 5
 }

--- a/src/test/resources/mappings/oauth2_token-successful.json
+++ b/src/test/resources/mappings/oauth2_token-successful.json
@@ -1,25 +1,25 @@
 {
-  "id" : "8935191e-b9ec-4616-9ee5-3d4fd22b7655",
+  "id" : "0b153d2e-cb62-4e65-90dc-839ece51f2e2",
   "name" : "oauth2_token",
   "request" : {
-    "url" : "/oauth2/token?code=TkREejRRxTUp6U9u&grant_type=authorization_code&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver&client_id=bsp&client_secret=123456",
+    "url" : "/oauth2/token",
     "method" : "POST",
     "bodyPatterns" : [ {
-      "equalTo" : "{code=TkREejRRxTUp6U9u, grant_type=authorization_code, redirect_uri=https://localhost/receiver, client_secret=123456, client_id=bsp}",
+      "equalTo" : "code=eEdhNnasWy7eNFAV&grant_type=authorization_code&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver&client_secret=123456&client_id=bsp",
       "caseInsensitive" : false
     } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"access_token\":\"eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzYTY3MmJkdm5tYW1sZmFlaDB2ODFia2V1NyIsInN1YiI6IjI0IiwiaWF0IjoxNTUwNjY2ODM0LCJleHAiOjE1NTA2OTU2MzQsImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlci1zc2NzLWxvYTAiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIyNCIsImZvcmVuYW1lIjoiQnVsayBTY2FuIiwic3VybmFtZSI6IlN5c3RlbSBVcGRhdGUiLCJkZWZhdWx0LXNlcnZpY2UiOiJCU1AiLCJsb2EiOjAsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvYnNwIiwiZ3JvdXAiOiJic3Atc3lzdGVtdXBkYXRlIn0.BbVZAYAkRq5o0aPD5TIk-jmVeo20f9RPNPUFYhrbz5s\",\"token_type\":\"Bearer\",\"expires_in\":28800}",
+    "body" : "{\"access_token\":\"eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ1c2FubmJyaGV2OWI0dGxzMzhyMTI4dGdycCIsInN1YiI6IjI0IiwiaWF0IjoxNTUwNjk1Nzc5LCJleHAiOjE1NTA3MjQ1NzksImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlci1zc2NzLWxvYTAiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIyNCIsImZvcmVuYW1lIjoiQnVsayBTY2FuIiwic3VybmFtZSI6IlN5c3RlbSBVcGRhdGUiLCJkZWZhdWx0LXNlcnZpY2UiOiJCU1AiLCJsb2EiOjAsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvYnNwIiwiZ3JvdXAiOiJic3Atc3lzdGVtdXBkYXRlIn0.PdjD2Kjz6myH1p44CRCVztkl2lqkg0LXqiyoH7Hs2bg\",\"token_type\":\"Bearer\",\"expires_in\":28800}",
     "headers" : {
       "X-Application-Context" : "application",
       "Content-Type" : "application/json;charset=UTF-8",
       "Vary" : "Accept-Encoding",
-      "Date" : "Wed, 20 Feb 2019 12:47:14 GMT"
+      "Date" : "Wed, 20 Feb 2019 20:49:39 GMT"
     }
   },
-  "uuid" : "8935191e-b9ec-4616-9ee5-3d4fd22b7655",
+  "uuid" : "0b153d2e-cb62-4e65-90dc-839ece51f2e2",
   "persistent" : true,
-  "insertionIndex" : 3
+  "insertionIndex" : 4
 }

--- a/src/test/resources/mappings/oauth2_token-successful.json
+++ b/src/test/resources/mappings/oauth2_token-successful.json
@@ -1,21 +1,25 @@
 {
-  "id" : "8dc06854-c86c-4917-a010-6feae9eb885a",
+  "id" : "8935191e-b9ec-4616-9ee5-3d4fd22b7655",
   "name" : "oauth2_token",
   "request" : {
-    "url" : "/oauth2/token?code=6GugDwpBcfq5E549&grant_type=authorization_code&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver&client_id=bsp&client_secret=123456",
-    "method" : "POST"
+    "url" : "/oauth2/token?code=TkREejRRxTUp6U9u&grant_type=authorization_code&redirect_uri=https%3A%2F%2Flocalhost%2Freceiver&client_id=bsp&client_secret=123456",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalTo" : "{code=TkREejRRxTUp6U9u, grant_type=authorization_code, redirect_uri=https://localhost/receiver, client_secret=123456, client_id=bsp}",
+      "caseInsensitive" : false
+    } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"access_token\":\"eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ2YjRrYTlwYWc5a2x2a3Bqczhqb241bDhrdCIsInN1YiI6IjMxIiwiaWF0IjoxNTM3MzcwMDgxLCJleHAiOjE1MzczOTg4ODEsImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlcixjYXNld29ya2VyLXNzY3MtbG9hMSxjYXNld29ya2VyLWxvYTEiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIzMSIsImZvcmVuYW1lIjoiQ2FzZSIsInN1cm5hbWUiOiJXb3JrZXIiLCJkZWZhdWx0LXNlcnZpY2UiOiJDQ0QiLCJsb2EiOjEsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvY2NkIiwiZ3JvdXAiOiJjYXNld29ya2VyIn0.F3qGuDsFb_8hgyFHMNjEow0RMTTaBz2VIuRTZpbVa80\",\"token_type\":\"Bearer\",\"expires_in\":28800}",
+    "body" : "{\"access_token\":\"eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzYTY3MmJkdm5tYW1sZmFlaDB2ODFia2V1NyIsInN1YiI6IjI0IiwiaWF0IjoxNTUwNjY2ODM0LCJleHAiOjE1NTA2OTU2MzQsImRhdGEiOiJjYXNld29ya2VyLXNzY3MsY2FzZXdvcmtlci1zc2NzLWxvYTAiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIyNCIsImZvcmVuYW1lIjoiQnVsayBTY2FuIiwic3VybmFtZSI6IlN5c3RlbSBVcGRhdGUiLCJkZWZhdWx0LXNlcnZpY2UiOiJCU1AiLCJsb2EiOjAsImRlZmF1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvYnNwIiwiZ3JvdXAiOiJic3Atc3lzdGVtdXBkYXRlIn0.BbVZAYAkRq5o0aPD5TIk-jmVeo20f9RPNPUFYhrbz5s\",\"token_type\":\"Bearer\",\"expires_in\":28800}",
     "headers" : {
       "X-Application-Context" : "application",
       "Content-Type" : "application/json;charset=UTF-8",
       "Vary" : "Accept-Encoding",
-      "Date" : "Wed, 19 Sep 2018 15:14:41 GMT"
+      "Date" : "Wed, 20 Feb 2019 12:47:14 GMT"
     }
   },
-  "uuid" : "8dc06854-c86c-4917-a010-6feae9eb885a",
+  "uuid" : "8935191e-b9ec-4616-9ee5-3d4fd22b7655",
   "persistent" : true,
-  "insertionIndex" : 2
+  "insertionIndex" : 3
 }


### PR DESCRIPTION

### Change description ###

-  This PR is just an enabler to integrate with Sidam. It adds a request body so that MS IIS accepts the request.

- Setting the Content-Length to 0 doesn't help as it will be removed by Spring Cloud Feign Client implementation.

- At some point we will need to move to new Sidam endpoint and completely mark existing endpoints as deprecated. 

- Please note that we will need to add more tests to this client so that we can validate the request body and headers passed to the server. This will be done as a separate ticket.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```