### PR TITLE
Update openfeign

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,8 +143,8 @@ dependencyManagement {
 dependencies {
     api group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
     api group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    api group: 'io.github.openfeign', name: 'feign-jackson', version: 10.2.3
-    api group: 'io.github.openfeign', name: 'feign-httpclient', version: 10.2.3
+    api group: 'io.github.openfeign', name: 'feign-jackson', version: '10.2.3'
+    api group: 'io.github.openfeign', name: 'feign-httpclient', version: '10.2.3'
     api group: 'io.github.openfeign.form', name: 'feign-form', version: feignFormVersion
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.2'
+version '1.0.3'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
@@ -131,7 +131,6 @@ bintray {
 ext {
     lombokVersion = '1.18.2'
     springCloudVersion = 'Greenwich.RELEASE'
-    feignVersion = '10.1.0'
     feignFormVersion = '3.5.0'
 }
 
@@ -144,8 +143,8 @@ dependencyManagement {
 dependencies {
     api group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
     api group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    api group: 'io.github.openfeign', name: 'feign-jackson', version: feignVersion
-    api group: 'io.github.openfeign', name: 'feign-httpclient', version: feignVersion
+    api group: 'io.github.openfeign', name: 'feign-jackson', version: 10.2.3
+    api group: 'io.github.openfeign', name: 'feign-httpclient', version: 10.2.3
     api group: 'io.github.openfeign.form', name: 'feign-form', version: feignFormVersion
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion


### PR DESCRIPTION
`10.1.0` -> `10.2.3`

We're getting NPE when calling `.contentUTF8()` on `FeignException` in bulk-scan-orchestrator.
This was fixed here: https://github.com/OpenFeign/feign/pull/914

Also moving version back to dependency declaration in `build.gradle`.
I assume ext var was the reason dependabot didn't create a PR earlier?