### PR TITLE
Fix for handling re-directs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.idam.client;
 
 import feign.Response;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -77,7 +77,7 @@ public class IdamClient {
         final String redirectUri = URLEncoder.encode(
             oauth2Configuration.getRedirectUri(), StandardCharsets.UTF_8.toString());
         final Response response =  idamApi.authenticatePinUser(pin, clientId, redirectUri, state);
-        if (response.status() != HttpStatus.SC_OK) {
+        if (response.status() != HttpStatus.FOUND.value()) {
             return null;
         }
         final String code = getCodeFromRedirect(response);

--- a/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
@@ -183,7 +183,7 @@ public class IdamClientTest {
         final String PIN_ENDPOINT = String.format("/pin?client_id=%s&redirect_uri=%s&state", CLIENT_ID, redirectUri);
         idamApiServer.stubFor(WireMock.get(PIN_ENDPOINT)
             .willReturn(aResponse()
-                .withStatus(HttpStatus.OK.value())
+                .withStatus(HttpStatus.FOUND.value())
                 .withHeader(HttpHeaders.LOCATION, PIN_REDIRECT_URL)
             )
         );


### PR DESCRIPTION
Adapts the default http client to handle redirects appropriately (i.e. do not automatically follow them). Also adds request timeout of 10 seconds.

[Based on this snippet.](https://github.com/spring-cloud/spring-cloud-openfeign/issues/98#issuecomment-448682473)