### PR TITLE
Add support for OIDC user info endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,7 @@ dependencies {
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.5.2'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
 
     testCompile group: 'com.github.tomakehurst', name:'wiremock-jre8', version: wiremockVersion
 

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 @FeignClient(name = "idam-api", url = "${idam.api.url}", configuration = CoreFeignConfiguration.class)
 public interface IdamApi {
@@ -61,5 +62,12 @@ public interface IdamApi {
     )
     TokenExchangeResponse exchangeCode(
         @RequestBody ExchangeCodeRequest exchangeCodeRequest
+    );
+
+    @GetMapping(
+            value = "/o/userinfo"
+    )
+    UserInfo retrieveUserInfo(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamApi.java
@@ -21,16 +21,12 @@ import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 @FeignClient(name = "idam-api", url = "${idam.api.url}", configuration = CoreFeignConfiguration.class)
 public interface IdamApi {
 
-    @GetMapping(
-        value = "/details"
-    )
+    @GetMapping("/details")
     UserDetails retrieveUserDetails(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     );
 
-    @PostMapping(
-        value = "/pin"
-    )
+    @PostMapping("/pin")
     GeneratePinResponse generatePin(
         GeneratePinRequest requestBody,
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
@@ -64,10 +60,8 @@ public interface IdamApi {
         @RequestBody ExchangeCodeRequest exchangeCodeRequest
     );
 
-    @GetMapping(
-            value = "/o/userinfo"
-    )
+    @GetMapping("/o/userinfo")
     UserInfo retrieveUserInfo(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -92,5 +93,9 @@ public class IdamClient {
 
         UriComponents build = UriComponentsBuilder.fromUriString(location).build();
         return build.getQueryParams().getFirst(CODE);
+    }
+
+    public UserInfo getUserInfo(String bearerToken) {
+        return idamApi.retrieveUserInfo(bearerToken);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/models/UserInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/models/UserInfo.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.idam.client.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserInfo {
+    private String sub;
+    private String uid;
+    private String name;
+    @JsonProperty("given_name")
+    private String givenName;
+    @JsonProperty("family_name")
+    private String familyName;
+    private List<String> roles;
+}

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/models/UserInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/models/UserInfo.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/models/UserInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/models/UserInfo.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Adds method to client and API classes to retrieve user information from OIDC `/o/userinfo` endpoint.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
