### PR TITLE
return just token not all token object

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenRequest;
-import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
@@ -48,7 +47,7 @@ public class IdamClient {
         return idamApi.retrieveUserDetails(bearerToken);
     }
 
-    public TokenResponse getAccessToken(String username, String password) {
+    public String getAccessToken(String username, String password) {
         TokenRequest tokenRequest =
             new TokenRequest(
                 oauth2Configuration.getClientId(),
@@ -61,7 +60,7 @@ public class IdamClient {
                 null,
                 null
             );
-        return idamApi.generateOpenIdToken(tokenRequest);
+        return idamApi.generateOpenIdToken(tokenRequest).accessToken;
     }
 
     public String authenticateUser(String username, String password) {

--- a/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
@@ -27,7 +27,6 @@ import uk.gov.hmcts.reform.idam.client.models.ExchangeCodeRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
-import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
@@ -169,8 +168,8 @@ public class IdamClientTest {
     @Test
     public void getAccessToken() {
         stubForOpenIdToken(HttpStatus.OK);
-        final TokenResponse tokenResponse = idamClient.getAccessToken(USER_LOGIN, USER_PASSWORD);
-        assertThat(tokenResponse.accessToken).isEqualTo(TOKEN);
+        final String token = idamClient.getAccessToken(USER_LOGIN, USER_PASSWORD);
+        assertThat(token).isEqualTo(TOKEN);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1120

### Change description ###

return just token not all token object
we do not need whole token object unless we want to cache outside this api?

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
