### PR TITLE
Appended Bearer before returning access token for new openid endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -60,7 +60,7 @@ public class IdamClient {
                 null,
                 null
             );
-        return idamApi.generateOpenIdToken(tokenRequest).accessToken;
+        return BEARER_AUTH_TYPE + " " + idamApi.generateOpenIdToken(tokenRequest).accessToken;
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
@@ -169,7 +169,7 @@ public class IdamClientTest {
     public void getAccessToken() {
         stubForOpenIdToken(HttpStatus.OK);
         final String token = idamClient.getAccessToken(USER_LOGIN, USER_PASSWORD);
-        assertThat(token).isEqualTo(TOKEN);
+        assertThat(token).isEqualTo(BEARER + TOKEN);
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

- Currently Bearer is not appended to the access token as a result bulk scan orchestrator and bulk scan payment processor are failing while searching cases in CCD.

- Requests will be rejected by OpenId code in ccd (Spring filter) if we don't have Bearer appended to Idam access token.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
