### PR TITLE
return whole openid response object

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenRequest;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
@@ -47,8 +48,9 @@ public class IdamClient {
         return idamApi.retrieveUserDetails(bearerToken);
     }
 
-    public String getAccessToken(String username, String password) {
-        TokenRequest tokenRequest =
+    // when using the acess token you may need to add "Bearer "
+    public TokenResponse getAccessTokenResponse(String username, String password) {
+        return idamApi.generateOpenIdToken(
             new TokenRequest(
                 oauth2Configuration.getClientId(),
                 oauth2Configuration.getClientSecret(),
@@ -59,8 +61,11 @@ public class IdamClient {
                 OPENID_SCOPE,
                 null,
                 null
-            );
-        return BEARER_AUTH_TYPE + " " + idamApi.generateOpenIdToken(tokenRequest).accessToken;
+            ));
+    }
+
+    public String getAccessToken(String username, String password) {
+        return BEARER_AUTH_TYPE + " " + getAccessTokenResponse(username, password).accessToken;
     }
 
     public String authenticateUser(String username, String password) {

--- a/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/client/IdamClient.java
@@ -48,7 +48,7 @@ public class IdamClient {
         return idamApi.retrieveUserDetails(bearerToken);
     }
 
-    // when using the acess token you may need to add "Bearer "
+    // when using the access token you may need to add "Bearer "
     public TokenResponse getAccessTokenResponse(String username, String password) {
         return idamApi.generateOpenIdToken(
             new TokenRequest(

--- a/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/client/IdamClientTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.reform.idam.client.models.ExchangeCodeRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinRequest;
 import uk.gov.hmcts.reform.idam.client.models.GeneratePinResponse;
 import uk.gov.hmcts.reform.idam.client.models.TokenExchangeResponse;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
@@ -65,7 +66,7 @@ public class IdamClientTest {
 
     private final String OPENID_TOKEN_RESULT = String.format(
             "{\"access_token\":\"%s\",\"refresh_token\":\"%s\",\"id_token\":\"%s\",\"token_type\":\"Bearer\","
-                    + "\"scope\": \"openid+profile+roles\",\"expires_in\":28800}", TOKEN, REFRESH_TOKEN, ID_TOKEN);
+                    + "\"scope\": \"openid profile roles\",\"expires_in\":28800}", TOKEN, REFRESH_TOKEN, ID_TOKEN);
 
     private final String USER_LOGIN = "user@example.com";
     private final String USER_PASSWORD = "Password12";
@@ -170,6 +171,18 @@ public class IdamClientTest {
         stubForOpenIdToken(HttpStatus.OK);
         final String token = idamClient.getAccessToken(USER_LOGIN, USER_PASSWORD);
         assertThat(token).isEqualTo(BEARER + TOKEN);
+    }
+
+    @Test
+    public void getAccessTokenResponse() {
+        stubForOpenIdToken(HttpStatus.OK);
+        final TokenResponse tokenResponse = idamClient.getAccessTokenResponse(USER_LOGIN, USER_PASSWORD);
+        assertThat(tokenResponse.accessToken).isEqualTo(TOKEN);
+        assertThat(tokenResponse.expiresIn).isEqualTo("28800");
+        assertThat(tokenResponse.idToken).isEqualTo(ID_TOKEN);
+        assertThat(tokenResponse.refreshToken).isEqualTo(REFRESH_TOKEN);
+        assertThat(tokenResponse.scope).isEqualTo("openid profile roles");
+        assertThat(tokenResponse.tokenType).isEqualTo("Bearer");
     }
 
     @Test


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1120

### Change description ###

return whole openid response object.
So do not need to decode accesstoken to get expire_in, 
and there other fields that can be useful for caller 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
