### PR TITLE
update spring dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ This is a client library for interacting with the idam application.
 
 ## Usage
 
-Just include the library as your dependency and you will be to use the client class.
+Add the library as a dependency of your project and configure the spring application to scan for Feign clients in the `uk.gov.hmcts.reform.idam` package:
+
+```java
+@EnableFeignClients(basePackages = {"uk.gov.hmcts.reform.idam"})
+public class YourSpringApplication { }
+```
+
 You will also need to set the spring configuration property of `idam.api.url` 
 
 Optionally if you are authenticating a user you can use provide client configuration:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'checkstyle'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'org.springframework.boot' version '2.4.2'
     id 'com.jfrog.bintray' version '1.8.5'
     id 'com.github.ben-manes.versions' version '0.36.0'
     id 'org.owasp.dependencycheck' version '6.0.3'
@@ -189,10 +189,10 @@ bintray {
 
 ext {
     lombokVersion = '1.18.8'
-    springCloudVersion = 'Hoxton.SR9'
+    springCloudVersion = '2020.0.1'
 }
 
-ext["spring-cloud-openfeign.version"] = "2.2.2.RELEASE"
+ext["spring-cloud-openfeign.version"] = "3.0.1"
 
 dependencyManagement {
     imports {


### PR DESCRIPTION
Updating the spring packages to 2.4 / spring cloud 2020.0.1

Note that this change may be backwards incompatible depending how you have configured feign. I needed to update the feign configuration to scan the `uk.gov.hmcts.reform.idam` package otherwise it would ignore the IdamApi provided:

```
@EnableFeignClients(basePackages = {"uk.gov.hmcts.reform.divorce", "uk.gov.hmcts.reform.idam"})
@SpringBootApplication(scanBasePackages = {"uk.gov.hmcts.reform.divorce",
    "uk.gov.hmcts.reform.logging.appinsights" } ,
    exclude = {ServiceAuthAutoConfiguration.class})
public class CaseMaintenanceServiceApplication {
```